### PR TITLE
update to reflect new model in api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.xpi
 funkyold
 data/secret.js
+archive/
 
 # Windows image file caches
 Thumbs.db

--- a/data/content.js
+++ b/data/content.js
@@ -52,7 +52,7 @@ function getIndex() {
 	xhr.onload = function(e) {
 		console.log(this.response);
 		indexResponse = this.response;
-		currIndex = indexResponse.currid[0].currid;
+		currIndex = indexResponse.currid;
 		console.log(currIndex);
 		window.postMessage({
 				"currIndex": currIndex,


### PR DESCRIPTION
the api now sensibly returns the current image index as `{ key: value}` rather than `[{ key: value }]`
